### PR TITLE
Add support to return the version of stable Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ const findChromeVersion = require("find-chrome-version");
   console.log(`Your Chrome version is ${chromeVersion}`);
 })();
 ```
+
+By default, this will return the Canary version if you installed both the stable version and the Canary version,
+If you prefer the stable version, pass `{ stable: true }` to it.

--- a/index.js
+++ b/index.js
@@ -1,18 +1,32 @@
-const ChromeLauncher = require("chrome-launcher")
-const CDP = require("chrome-remote-interface")
+const execa = require('execa')
+const { Launcher } = require('chrome-launcher')
 
-const chromeFlags = [
-  "--no-sandbox",
-  "--headless",
-]
+const regExp = /\d+\.\d+\.\d+\.\d+/
 
-const regExp = /HeadlessChrome\/(.*)/
+module.exports = async (options = {}) => {
+  const { stable } = options;
+  const installs = Launcher.getInstallations()
+  const chrome = stable ? installs.find(item => {
+    if (item.indexOf('stable') > 0) {
+      return true
+    }
+    // Skip canary version, chromium and chrome-wrapper
+    if (/canary|sxs|chromium|wrapper/i.test(item)) {
+      return false
+    }
+    return true
+  }) : installs[0]
 
-module.exports = async () => {
-  const chrome = await ChromeLauncher.launch({ chromeFlags })
-  const protocol = await CDP({ port: chrome.port })
-  const { product } = await protocol.Browser.getVersion()
-  protocol.close()
-  chrome.kill()
-  return regExp.exec(product)[1]
+  if (!chrome) {
+    throw new Error('Chrome installation not found')
+  }
+
+  let result
+  // Windows
+  if (process.platform === 'win32') {
+    result = await execa('wmic', ['datafile', 'where', `name="${chrome.replace(/\\/g, '\\\\')}"`, 'get', 'Version', '/value'])
+  } else {
+    result = await execa(chrome, ['--version'])
+  }
+  return result.stdout.match(regExp)[0]
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test": "mocha ./test.js --timeout 10000"
   },
   "dependencies": {
-    "chrome-launcher": "^0.11.2",
-    "chrome-remote-interface": "^0.28.0"
+    "chrome-launcher": "^0.12.0",
+    "execa": "^3.4.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Thanks for the useful module.

I found that this issue will return the Canary version of Chrome if I installed both the stable version and the Canary version. Because the chrome finder defined the priority of the installation and the Canary version has a high priority.

https://github.com/GoogleChrome/chrome-launcher/blob/b8c89f84a39c2f4ed4dd547be5dce2d83da54424/src/chrome-finder.ts#L21

So, I add an option `{ stable: true }` to return the stable version.

I also removed the chrome-remote-interface module, the version can be got without launch the Chrome in the background. It should be much faster now.
